### PR TITLE
Update ExchangeRate

### DIFF
--- a/CryptoPay/Types/ExchangeRate.cs
+++ b/CryptoPay/Types/ExchangeRate.cs
@@ -27,7 +27,8 @@ public class ExchangeRate
     ///     Target currency. 
     /// </summary>
     [JsonProperty(Required = Required.Always)]
-    public string Target { get; set; }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public Assets Target { get; set; }
 
     /// <summary>
     ///     Exchange rate.


### PR DESCRIPTION
Is it possible to change the type of the "Target" property from string to Asset? Given the recent changes to Assets, this would be very handy.