### PR TITLE
Fix exception: The JSON value could not be converted to CryptoPay.Types.Assets.

### DIFF
--- a/CryptoPay/Types/Assets.cs
+++ b/CryptoPay/Types/Assets.cs
@@ -142,6 +142,11 @@ public enum Assets
     BRL = 114,
 
     /// <summary>
+    /// Indonesian rupiah
+    /// </summary>
+    IDR = 115,
+
+    /// <summary>
     /// Azerbaijani manat
     /// </summary>
     AZN = 116,

--- a/CryptoPay/Types/Assets.cs
+++ b/CryptoPay/Types/Assets.cs
@@ -164,5 +164,15 @@ public enum Assets
     /// <summary>
     /// Israeli new shekel
     /// </summary>
-    ILS = 119
+    ILS = 119,
+
+    /// <summary>
+    /// Kyrgyz som
+    /// </summary>
+    KGS = 120,
+
+    /// <summary>
+    /// Tajikistani somoni
+    /// </summary>
+    TJS = 121
 }


### PR DESCRIPTION
When called into the GetExchangeRatesAsync method, it constantly throws an exception if the CryptoBot developers add a new Asset. Maybe create some new enum converter instead of JsonStringEnumConverter so that it marks such values as Unknown or something like that?