### PR TITLE
CreateInvoice fix

### DIFF
--- a/CryptoPay.Tests/AvailableMethodsTests.cs
+++ b/CryptoPay.Tests/AvailableMethodsTests.cs
@@ -110,7 +110,6 @@ public class AvailableMethodsTests
             Assert.Equal(invoiceRequest.Asset, invoice.Asset);
             Assert.Equal(AssetsHelper.TryParse(invoiceRequest.Asset), AssetsHelper.TryParse(invoice.Asset));
             Assert.Equal(invoiceRequest.Fiat, invoice.Fiat);
-            // Assert.Equal(invoiceRequest.AcceptedAssets, invoice.AcceptedAssets);
             Assert.Equal(invoiceRequest.Description, invoice.Description);
             Assert.Equal(invoiceRequest.HiddenMessage, invoice.HiddenMessage);
             Assert.Equal(invoiceRequest.PaidBtnName, invoice.PaidBtnName);
@@ -119,6 +118,12 @@ public class AvailableMethodsTests
             Assert.Equal(invoiceRequest.AllowComments!.Value, invoice.AllowComments);
             Assert.Equal(invoiceRequest.AllowAnonymous!.Value, invoice.AllowAnonymous);
             Assert.Equal(invoice.CreatedAt.AddSeconds(invoiceRequest.ExpiresIn).ToString("g"), invoice.ExpirationDate?.ToString("g"));
+            
+            if (invoiceRequest.CurrencyType == CurrencyTypes.fiat) 
+            {
+                if (invoiceRequest.AcceptedAssets is null) Assert.NotEmpty(invoice.AcceptedAssets);
+                else Assert.Equal(invoiceRequest.AcceptedAssets, invoice.AcceptedAssets);
+            }
         }
         catch (RequestException requestException)
         {

--- a/CryptoPay.Tests/TestData/CreateInvoiceData.cs
+++ b/CryptoPay.Tests/TestData/CreateInvoiceData.cs
@@ -76,6 +76,19 @@ public class CreateInvoiceData : TheoryData<HttpStatusCode, Error?, CreateInvoic
                 false,
                 360)
         );
+        
+        this.Add(
+            default,
+            default,
+            new CreateInvoiceRequest(
+                1.23,
+                CurrencyTypes.fiat,
+                default,
+                Assets.EUR.ToString(),
+                new []{ Assets.TON.ToString(), Assets.USDT.ToString() },
+                "description",
+                "hiddenMessage")
+        );
 
         this.Add(
             HttpStatusCode.BadRequest,

--- a/CryptoPay/Converters/ArrayToStringConverter.cs
+++ b/CryptoPay/Converters/ArrayToStringConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CryptoPay.Converters;
+
+/// <summary>
+/// Custom JSON converter to serialize an array of strings as a single comma-separated string and deserialize it back to an array.
+/// </summary>
+public class ArrayToStringConverter : JsonConverter<IEnumerable<string>>
+{
+    /// <inheritdoc />
+    public override IEnumerable<string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return JsonSerializer.Deserialize<List<string>>(ref reader, options);
+    }
+    
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, IEnumerable<string> value, JsonSerializerOptions options)
+    {
+        var joinedString = string.Join(",", value);
+        writer.WriteStringValue(joinedString);
+    }
+}

--- a/CryptoPay/Requests/CreateInvoiceRequest.cs
+++ b/CryptoPay/Requests/CreateInvoiceRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using CryptoPay.Converters;
 using CryptoPay.Requests.Base;
 using CryptoPay.Types;
 
@@ -107,6 +108,7 @@ public sealed class CreateInvoiceRequest
     public CurrencyTypes CurrencyType { get; set; }
 
     /// <inheritdoc />
+    [JsonConverter(typeof(ArrayToStringConverter))]
     public IEnumerable<string> AcceptedAssets { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Fix problem with create invoice error `Code: 500 Name: APP_ERROR` when use `acceptedAssets` field.
It happens because Request value of `acceptedAssets` field must be **[Comma-separated string](http://help.crypt.bot/crypto-pay-api#OZh6)** - e.g. _"BTC, TON, USDT"_.
And Response returns array of strings - _["BTC", "TON", "USDT"]_
